### PR TITLE
Hacktoberfest: Take out double mention of freecodecamp in resources.json

### DIFF
--- a/assets/json/resources.json
+++ b/assets/json/resources.json
@@ -144,12 +144,6 @@
         "link": "https://www.youtube.com/channel/UCtxCXg-UvSnTKPOzLHwJaQ"
     },
     {
-        "title": "FreeCodeCamp",
-        "description": "We're an open source community of busy people who learn to code and build projects for nonprofits. And let others learn. ",
-        "imgSrc": "https://i.chzbgr.com/full/7711237/h0DF66DC/",
-        "link": "https://www.youtube.com/channel/UC8butISFwT-Wl7EV0hUK0BQ"
-    },
-    {
         "title": "JSConf",
         "description": "JSConf is a series of JavaScript conferences from around the world.Find the Talks here. ",
         "imgSrc": "https://jsconf.com/images/jsconf_ar.png",


### PR DESCRIPTION
In the resources, freecodecamp was mentioned twice. One mention has been taken out (it was the least professional of the two with bad pictures instead of a logo).